### PR TITLE
Update dateparser to 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dateparser==1.0.0
+dateparser==1.2.0
 juntagrico~=1.5.0
 requests==2.25.1


### PR DESCRIPTION
This was needed to parse a date string like `Wed, 13 Sep 2023 13:35:56 GMT`,

With dateparser 1.0.0 this failed, with 1.2.0 it worked :)

Thanks a lot for this package, it is really handy!